### PR TITLE
Fix auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 venv/
+__pycache__

--- a/auth.py
+++ b/auth.py
@@ -78,6 +78,8 @@ def login(data, input_url=None, password=None, verify=True,
             basic_pass = getpass.getpass('Basic password:')
         elif basic_pass is None and password is not None:
             basic_pass = password
+        elif basic_pass and password:
+            pass
         else:
             common.log_output("A password is required required", True)
             sys.exit(2)

--- a/auth.py
+++ b/auth.py
@@ -87,7 +87,7 @@ def login(data, input_url=None, password=None, verify=True,
         # Create the authorization string
         basic_auth = "Basic " + secret.decode('utf-8')
         headers = {"Authorization": basic_auth}
-        r = requests.get(baseurl, verify=verify, headers=headers,
+        r = requests.get(baseurl, verify=verify,
                          allow_redirects=True)
         common.check_response(data, r.status_code)
         if r.status_code == 200:
@@ -114,7 +114,7 @@ def login(data, input_url=None, password=None, verify=True,
         baseurl = common.create_baseurl(data, "/login.cgi")
         headers = common.create_headers(data)
         payload = {'get-nonce': 1}
-        r = requests.post(baseurl, headers=headers, data=payload, verify=verify)
+        r = requests.post(baseurl, data=payload, verify=verify)
         if r.status_code != 200:
             common.log_output("Error getting salt from server", True, r.status_code)
             sys.exit(2)
@@ -136,7 +136,7 @@ def login(data, input_url=None, password=None, verify=True,
             "xsrf-token": token,
             "session-nonce": data.get("nonce", "")
         }
-        r = requests.post(baseurl, headers=headers, data=payload,
+        r = requests.post(baseurl, data=payload,
                           cookies=cookies, verify=verify)
         common.check_response(data, r.status_code)
         if r.status_code == 200:

--- a/auth.py
+++ b/auth.py
@@ -87,7 +87,7 @@ def login(data, input_url=None, password=None, verify=True,
         # Create the authorization string
         basic_auth = "Basic " + secret.decode('utf-8')
         headers = {"Authorization": basic_auth}
-        r = requests.get(baseurl, verify=verify,
+        r = requests.get(baseurl, verify=verify, headers=headers,
                          allow_redirects=True)
         common.check_response(data, r.status_code)
         if r.status_code == 200:
@@ -114,9 +114,11 @@ def login(data, input_url=None, password=None, verify=True,
         baseurl = common.create_baseurl(data, "/login.cgi")
         headers = common.create_headers(data)
         payload = {'get-nonce': 1}
-        r = requests.post(baseurl, data=payload, verify=verify)
+        r = requests.post(baseurl, headers=headers, data=payload,
+                          verify=verify)
         if r.status_code != 200:
-            common.log_output("Error getting salt from server", True, r.status_code)
+            common.log_output("Error getting salt from server", True,
+                              r.status_code)
             sys.exit(2)
 
         salt = r.json()["Salt"]
@@ -136,12 +138,13 @@ def login(data, input_url=None, password=None, verify=True,
             "xsrf-token": token,
             "session-nonce": data.get("nonce", "")
         }
-        r = requests.post(baseurl, data=payload,
+        r = requests.post(baseurl, headers=headers, data=payload,
                           cookies=cookies, verify=verify)
         common.check_response(data, r.status_code)
         if r.status_code == 200:
             common.log_output("Connected", False, r.status_code)
-            data["session-auth"] = compatibility.unquote(r.cookies["session-auth"])
+            data["session-auth"] = compatibility.unquote(
+                                        r.cookies["session-auth"])
         else:
             message = "Error authenticating against the server"
             common.log_output(message, True, r.status_code)

--- a/common.py
+++ b/common.py
@@ -112,10 +112,12 @@ def create_cookies(data):
 
 # Common function for creating headers to authenticate against the API
 def create_headers(data):
-    headers = {
-        "X-XSRF-TOKEN": data.get("token", "")
-    }
-
+    if data.get("token", None):
+        headers = {
+            "X-XSRF-TOKEN": data.get("token", "")
+        }
+    else:
+        headers = None
     # Add a basic auth header if available
     basic_auth = data.get('authorization', '')
     if basic_auth is not '':

--- a/common.py
+++ b/common.py
@@ -117,8 +117,8 @@ def create_headers(data):
     }
 
     # Add a basic auth header if available
-    basic_auth = data.get('authorization', None)
-    if basic_auth is not None:
+    basic_auth = data.get('authorization', '')
+    if basic_auth is not '':
         headers["Authorization"] = basic_auth
 
     return headers

--- a/duplicati_client.py
+++ b/duplicati_client.py
@@ -87,7 +87,8 @@ def main(**args):
         insecure = args.get("insecure", False)
         verify = auth.determine_ssl_validation(data, certfile, insecure)
         interactive = args.get("script", True)
-        data = auth.login(data, url, password, verify, interactive, basic_user, basic_pass)
+        data = auth.login(data, url, password, verify, interactive,
+                          basic_user, basic_pass)
 
     # Logout
     if method == "logout":

--- a/test_duplicati_client.py
+++ b/test_duplicati_client.py
@@ -4,6 +4,7 @@ from auth import login
 import common
 import requests
 
+
 class TestLogin(unittest.TestCase):
     def mock_check_response(self, mock_check_response):
         pass
@@ -21,11 +22,12 @@ class TestLogin(unittest.TestCase):
 
         if args[0] == 'http://duplicati_proxy:8200':
             headers = {'Server': 'nginx/1.13.8',
-                                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
-                                       'Content-Type': 'text/html',
-                                       'Content-Length': '195',
-                                       'Connection': 'keep-alive',
-                                       'WWW-Authenticate': 'Basic realm="Restricted sabnzbd.n0rmality.net"'
+                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
+                       'Content-Type': 'text/html',
+                       'Content-Length': '195',
+                       'Connection': 'keep-alive',
+                       'WWW-Authenticate':
+                       'Basic realm="Restricted duplicati.test.net"'
                        }
             return MockResponse(200, headers, args[0])
         elif args[0] == 'http://localhost:8200':
@@ -37,7 +39,8 @@ class TestLogin(unittest.TestCase):
                        'Server': 'Tiny WebServer',
                        'Keep-Alive': 'timeout=20, max=400',
                        'Connection': 'Keep-Alive'}
-            cookies = {"xsrf-token": "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D"}
+            cookies = {"xsrf-token":
+                       "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D"}
             return MockResponse(200, headers, args[0], cookies)
 
     def mock_requests_get_redirect(*args, **kwargs):
@@ -51,11 +54,12 @@ class TestLogin(unittest.TestCase):
 
         if args[0] == 'http://duplicati_proxy:8200':
             headers = {'Server': 'nginx/1.13.8',
-                                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
-                                       'Content-Type': 'text/html',
-                                       'Content-Length': '195',
-                                       'Connection': 'keep-alive',
-                                       'WWW-Authenticate': 'Basic realm="Restricted sabnzbd.n0rmality.net"'
+                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
+                       'Content-Type': 'text/html',
+                       'Content-Length': '195',
+                       'Connection': 'keep-alive',
+                       'WWW-Authenticate':
+                       'Basic realm="Restricted duplicati.test.net"'
                        }
             return MockResponse(200, headers, args[0])
         elif args[0] == 'http://localhost:8200':
@@ -67,7 +71,8 @@ class TestLogin(unittest.TestCase):
                        'Server': 'Tiny WebServer',
                        'Keep-Alive': 'timeout=20, max=400',
                        'Connection': 'Keep-Alive'}
-            cookies = {"xsrf-token": "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D"}
+            cookies = {"xsrf-token":
+                       "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D"}
             return MockResponse(200, headers, args[0], cookies)
 
     def mock_requests_post(*args, **kwargs):
@@ -82,14 +87,14 @@ class TestLogin(unittest.TestCase):
             def json(self):
                 return self.json_raw
 
-
         if args[0] == 'http://duplicati_proxy:8200':
             headers = {'Server': 'nginx/1.13.8',
-                                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
-                                       'Content-Type': 'text/html',
-                                       'Content-Length': '195',
-                                       'Connection': 'keep-alive',
-                                       'WWW-Authenticate': 'Basic realm="Restricted sabnzbd.n0rmality.net"'
+                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
+                       'Content-Type': 'text/html',
+                       'Content-Length': '195',
+                       'Connection': 'keep-alive',
+                       'WWW-Authenticate':
+                       'Basic realm="Restricted duplicati.test.net"'
                        }
             return MockResponse(200, headers, args[0])
         elif args[0] == 'http://localhost:8200/login.cgi':
@@ -101,18 +106,22 @@ class TestLogin(unittest.TestCase):
                        'Server': 'Tiny WebServer',
                        'Keep-Alive': 'timeout=20, max=400',
                        'Connection': 'Keep-Alive'}
-            cookies = {"xsrf-token": "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D",
-                       "session-auth": "63bgjHEmpOrQuZS2ubupqBiB5mJeU9A3yQWbSQql1n0"}
+            cookies = {"xsrf-token":
+                       "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D",
+                       "session-auth":
+                       "63bgjHEmpOrQuZS2ubupqBiB5mJeU9A3yQWbSQql1n0"}
             json = {'Status': 'OK',
                     'Nonce': 'rK44ZOGiWJKk+aDluN/b60MlwXGbQcRc9SnuxSHv784=',
                     'Salt': 'H9euyRJMYftnoDGro2TC4tEMsQ/BCpZ5dVSBRN1cDC4='}
             return MockResponse(200, headers, args[0], cookies, json)
+
     @patch('common.check_response', side_effect=mock_check_response)
     @patch('requests.get', side_effect=mock_requests_get)
     @patch('common.write_config', side_effect=mock_write_config)
-
-    def test_integrated_auth_logged_in(self, mock_check_response, mock_requests_get, mock_write_config):
-        """This test case validates that login works when no login redirect happens"""
+    def test_integrated_auth_logged_in(self, mock_check_response,
+                                       mock_requests_get, mock_write_config):
+        """This test case validates that login works when no
+           login redirect happens"""
         data = {
             "last_login": None,
             "parameters_file": None,
@@ -138,8 +147,13 @@ class TestLogin(unittest.TestCase):
     @patch('requests.get', side_effect=mock_requests_get_redirect)
     @patch('common.write_config', side_effect=mock_write_config)
     @patch('requests.post', side_effect=mock_requests_post)
-    def test_integrated_auth_not_logged_in(self, mock_check_response, mock_requests_get, mock_write_config, mock_requests_post):
-        """This test case validates that login works when login redirect happens"""
+    def test_integrated_auth_not_logged_in(self, mock_check_response,
+                                           mock_requests_get,
+                                           mock_write_config,
+                                           mock_requests_post
+                                           ):
+        """This test case validates that login works when
+           login redirect happens"""
         data = {
             "last_login": None,
             "parameters_file": None,
@@ -161,6 +175,8 @@ class TestLogin(unittest.TestCase):
             self.assertEqual(auth, True)
         finally:
             pass
+
+
 class TestResponse(unittest.TestCase):
     def setUp(self):
         self.data = {
@@ -210,10 +226,12 @@ class TestResponse(unittest.TestCase):
         finally:
             pass
 
+
 class TestResponse200(unittest.TestCase):
-    #mocking the write_config function
+    # mocking the write_config function
     def mock_write_config(self):
         pass
+
     @patch('common.write_config', side_effect=mock_write_config)
     def test_response_200(self, write_config):
         data = {
@@ -231,4 +249,3 @@ class TestResponse200(unittest.TestCase):
             'authorization': ''
             }
         common.check_response(data, 200)
-

--- a/test_duplicati_client.py
+++ b/test_duplicati_client.py
@@ -199,7 +199,8 @@ class TestLogin(unittest.TestCase):
 
         try:
             auth = login(data, input_url=None, password='1234', verify=True,
-                         interactive=False, basic_user='duplicati', basic_pass='1234')
+                         interactive=False, basic_user='duplicati',
+                         basic_pass='1234')
             self.assertEqual(auth, True)
         finally:
             pass

--- a/test_duplicati_client.py
+++ b/test_duplicati_client.py
@@ -1,0 +1,234 @@
+import unittest
+from mock import patch
+from auth import login
+import common
+import requests
+
+class TestLogin(unittest.TestCase):
+    def mock_check_response(self, mock_check_response):
+        pass
+
+    def mock_write_config(self):
+        pass
+
+    def mock_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, status_code, headers, url, cookies):
+                self.status_code = status_code
+                self.headers = headers
+                self.url = url
+                self.cookies = cookies
+
+        if args[0] == 'http://duplicati_proxy:8200':
+            headers = {'Server': 'nginx/1.13.8',
+                                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
+                                       'Content-Type': 'text/html',
+                                       'Content-Length': '195',
+                                       'Connection': 'keep-alive',
+                                       'WWW-Authenticate': 'Basic realm="Restricted sabnzbd.n0rmality.net"'
+                       }
+            return MockResponse(200, headers, args[0])
+        elif args[0] == 'http://localhost:8200':
+            headers = {'Cache-Control': 'max-age=86400',
+                       'Last-modified': 'Mon, 02 Apr 2018 12:00:08 GMT',
+                       'Date': 'Wed, 13 Jun 2018 20:45:29 GMT',
+                       'Content-Length': '1189',
+                       'Content-Type': 'text/html; charset=utf-8',
+                       'Server': 'Tiny WebServer',
+                       'Keep-Alive': 'timeout=20, max=400',
+                       'Connection': 'Keep-Alive'}
+            cookies = {"xsrf-token": "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D"}
+            return MockResponse(200, headers, args[0], cookies)
+
+    def mock_requests_get_redirect(*args, **kwargs):
+        """simulates the redirect for login"""
+        class MockResponse:
+            def __init__(self, status_code, headers, url, cookies):
+                self.status_code = status_code
+                self.headers = headers
+                self.url = url + "/login.html"
+                self.cookies = cookies
+
+        if args[0] == 'http://duplicati_proxy:8200':
+            headers = {'Server': 'nginx/1.13.8',
+                                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
+                                       'Content-Type': 'text/html',
+                                       'Content-Length': '195',
+                                       'Connection': 'keep-alive',
+                                       'WWW-Authenticate': 'Basic realm="Restricted sabnzbd.n0rmality.net"'
+                       }
+            return MockResponse(200, headers, args[0])
+        elif args[0] == 'http://localhost:8200':
+            headers = {'Cache-Control': 'max-age=86400',
+                       'Last-modified': 'Mon, 02 Apr 2018 12:00:08 GMT',
+                       'Date': 'Wed, 13 Jun 2018 20:45:29 GMT',
+                       'Content-Length': '1189',
+                       'Content-Type': 'text/html; charset=utf-8',
+                       'Server': 'Tiny WebServer',
+                       'Keep-Alive': 'timeout=20, max=400',
+                       'Connection': 'Keep-Alive'}
+            cookies = {"xsrf-token": "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D"}
+            return MockResponse(200, headers, args[0], cookies)
+
+    def mock_requests_post(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, status_code, headers, url, cookies, json_raw):
+                self.status_code = status_code
+                self.headers = headers
+                self.url = url
+                self.cookies = cookies
+                self.json_raw = json_raw
+
+            def json(self):
+                return self.json_raw
+
+
+        if args[0] == 'http://duplicati_proxy:8200':
+            headers = {'Server': 'nginx/1.13.8',
+                                       'Date': 'Wed, 13 Jun 2018 18:28:32 GMT',
+                                       'Content-Type': 'text/html',
+                                       'Content-Length': '195',
+                                       'Connection': 'keep-alive',
+                                       'WWW-Authenticate': 'Basic realm="Restricted sabnzbd.n0rmality.net"'
+                       }
+            return MockResponse(200, headers, args[0])
+        elif args[0] == 'http://localhost:8200/login.cgi':
+            headers = {'Cache-Control': 'max-age=86400',
+                       'Last-modified': 'Mon, 02 Apr 2018 12:00:08 GMT',
+                       'Date': 'Wed, 13 Jun 2018 20:45:29 GMT',
+                       'Content-Length': '1189',
+                       'Content-Type': 'text/html; charset=utf-8',
+                       'Server': 'Tiny WebServer',
+                       'Keep-Alive': 'timeout=20, max=400',
+                       'Connection': 'Keep-Alive'}
+            cookies = {"xsrf-token": "sF02%2FyeH5oXieSAB%2FCRf4bsZuR1UHQGx5wmceEacWlg%3D",
+                       "session-auth": "63bgjHEmpOrQuZS2ubupqBiB5mJeU9A3yQWbSQql1n0"}
+            json = {'Status': 'OK',
+                    'Nonce': 'rK44ZOGiWJKk+aDluN/b60MlwXGbQcRc9SnuxSHv784=',
+                    'Salt': 'H9euyRJMYftnoDGro2TC4tEMsQ/BCpZ5dVSBRN1cDC4='}
+            return MockResponse(200, headers, args[0], cookies, json)
+    @patch('common.check_response', side_effect=mock_check_response)
+    @patch('requests.get', side_effect=mock_requests_get)
+    @patch('common.write_config', side_effect=mock_write_config)
+
+    def test_integrated_auth_logged_in(self, mock_check_response, mock_requests_get, mock_write_config):
+        """This test case validates that login works when no login redirect happens"""
+        data = {
+            "last_login": None,
+            "parameters_file": None,
+            "server": {
+                "port": "8200",
+                "protocol": "http",
+                "url": "localhost",
+                "verify": True
+                },
+            'token': None,
+            'token_expires': None,
+            'verbose': False,
+            'authorization': ''
+            }
+        try:
+            auth = login(data, input_url=None, password=None, verify=True,
+                         interactive=True, basic_user=None, basic_pass=None)
+            self.assertEqual(auth, True)
+        finally:
+            pass
+
+    @patch('common.check_response', side_effect=mock_check_response)
+    @patch('requests.get', side_effect=mock_requests_get_redirect)
+    @patch('common.write_config', side_effect=mock_write_config)
+    @patch('requests.post', side_effect=mock_requests_post)
+    def test_integrated_auth_not_logged_in(self, mock_check_response, mock_requests_get, mock_write_config, mock_requests_post):
+        """This test case validates that login works when login redirect happens"""
+        data = {
+            "last_login": None,
+            "parameters_file": None,
+            "server": {
+                "port": "8200",
+                "protocol": "http",
+                "url": "localhost",
+                "verify": True
+                },
+            'token': None,
+            'token_expires': None,
+            'verbose': False,
+            'authorization': ''
+            }
+
+        try:
+            auth = login(data, input_url=None, password='1234', verify=True,
+                         interactive=False, basic_user=None, basic_pass=None)
+            self.assertEqual(auth, True)
+        finally:
+            pass
+class TestResponse(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+            "last_login": None,
+            "parameters_file": None,
+            "server": {
+                "port": "8200",
+                "protocol": "http",
+                "url": "localhost",
+                "verify": True
+                },
+            'token': None,
+            'token_expires': None,
+            'verbose': False,
+            'authorization': ''
+            }
+
+    def test_response_400(self):
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                common.check_response(self.data, 400)
+            self.assertEqual(cm.exception.code, 2)
+        finally:
+            pass
+
+    def test_response_526(self):
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                common.check_response(self.data, 526)
+            self.assertEqual(cm.exception.code, 2)
+        finally:
+            pass
+
+    def test_response_495(self):
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                common.check_response(self.data, 495)
+            self.assertEqual(cm.exception.code, 2)
+        finally:
+            pass
+
+    def test_response_503(self):
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                common.check_response(self.data, 503)
+            self.assertEqual(cm.exception.code, 2)
+        finally:
+            pass
+
+class TestResponse200(unittest.TestCase):
+    #mocking the write_config function
+    def mock_write_config(self):
+        pass
+    @patch('common.write_config', side_effect=mock_write_config)
+    def test_response_200(self, write_config):
+        data = {
+            "last_login": None,
+            "parameters_file": None,
+            "server": {
+                "port": "8200",
+                "protocol": "http",
+                "url": "localhost",
+                "verify": True
+                },
+            'token': None,
+            'token_expires': None,
+            'verbose': False,
+            'authorization': ''
+            }
+        common.check_response(data, 200)
+


### PR DESCRIPTION
This addresses #7 . 
I believe the issue was authorization was defined as '' in config.yml. Then it was setting the basic auth header and trying to pass that along to the duplicati webserver. 
https://github.com/Pectojin/duplicati_client/blob/697b7f3b5675a0ae27d83ab8465d1c4ac5f42900/common.py#L120-L122
There was also an issue that when using basic auth the script would exit even though basic pass, password, and basic username were all defined.

I also added some unit tests.

I've tested the login process against basic auth and duplicati integrated auth.